### PR TITLE
Support shasum on Mac OS

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -6,7 +6,12 @@ if [[ ! -f .cache/google-java-format-1.6-all-deps.jar ]]
 then
     cd .cache && curl -LJO "https://github.com/google/google-java-format/releases/download/google-java-format-1.6/google-java-format-1.6-all-deps.jar"
 fi
-echo "73faf7c9b95bffd72933fa24f23760a6b1d18499151cb39a81cda591ceb7a5f4 *.cache/google-java-format-1.6-all-deps.jar" | sha256sum -c
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    echo "73faf7c9b95bffd72933fa24f23760a6b1d18499151cb39a81cda591ceb7a5f4 *.cache/google-java-format-1.6-all-deps.jar" | shasum -a 256 -c
+else
+    echo "73faf7c9b95bffd72933fa24f23760a6b1d18499151cb39a81cda591ceb7a5f4 *.cache/google-java-format-1.6-all-deps.jar" | sha256sum -c
+fi
 
 changed_java_files=$(git diff --cached --name-only --diff-filter=ACMR | grep ".*java$" || true)
 if [[ -n "$changed_java_files" ]]


### PR DESCRIPTION
On MacOS, the `sha256sum` is missing, use `shasum -a 256` instead